### PR TITLE
[releng] simpler way to add jfxswt.jar

### DIFF
--- a/de.fxdiagram.maven/Install_swtfx.sh
+++ b/de.fxdiagram.maven/Install_swtfx.sh
@@ -1,1 +1,0 @@
-mvn install:install-file -Dfile=/Library/Java/JavaVirtualMachines/jdk1.8.0_40.jdk/Contents/Home/jre/lib/jfxswt.jar -DgroupId=com.oracle -DartifactId=javafx.embedd.swt -Dversion=8.0.0-SNAPSHOT -Dpackaging=jar

--- a/de.fxdiagram.maven/pom.xml
+++ b/de.fxdiagram.maven/pom.xml
@@ -272,6 +272,8 @@
 			<groupId>com.oracle</groupId>
 			<artifactId>javafx.embedd.swt</artifactId>
 			<version>8.0.0-SNAPSHOT</version>
+			<scope>system</scope>
+    			<systemPath>${java.home}/lib/jfxswt.jar</systemPath>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Avoid extra installation check (with hard coded path to jfxswt.jar) by specifying the path in the pom.xml file itself.