### PR TITLE
[#54] Lower bundle-version restriction for org.eclipse.ui.ide to 3.10.0

### DIFF
--- a/de.fxdiagram.eclipse/META-INF/MANIFEST.MF
+++ b/de.fxdiagram.eclipse/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: de.fxdiagram.annotations,
  org.eclipse.ui.workbench.texteditor,
  org.eclipse.jface.text,
  org.eclipse.core.resources,
- org.eclipse.ui.ide;bundle-version="3.11.0"
+ org.eclipse.ui.ide;bundle-version="3.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: de.fxdiagram.eclipse,


### PR DESCRIPTION
3.10.0 is for targeting Eclipse Luna