### PR TITLE
[#57] Use empty string instead of null for empty emission

### DIFF
--- a/de.fxdiagram.core/src/de/fxdiagram/core/debug/Debug.xtend
+++ b/de.fxdiagram.core/src/de/fxdiagram/core/debug/Debug.xtend
@@ -57,19 +57,19 @@ class Debug {
 		var message = '''
 			Bounds of «class.simpleName»:
 				(«layoutX»:«layoutY») «layoutBounds»
-		 '''
-		 var current = it
-		 var currentPosition = new Point2D(layoutX, layoutY)
-		 var currentBounds = layoutBounds
-		 while(current.parent != null) {
-		 	currentBounds = current.localToParent(currentBounds)
-		 	currentPosition = current.localToParent(currentPosition)
-		 	message = message + '''
-		 		«null»	in «current.parent.class.simpleName»: («currentPosition.x»:«currentPosition.y») «currentBounds»
-		 	'''
-		 	current = current.parent
-		 }
-		 LOG.info(message)
+		'''
+		var current = it
+		var currentPosition = new Point2D(layoutX, layoutY)
+		var currentBounds = layoutBounds
+		while(current.parent != null) {
+			currentBounds = current.localToParent(currentBounds)
+			currentPosition = current.localToParent(currentPosition)
+			message = message + '''
+				«""»	in «current.parent.class.simpleName»: («currentPosition.x»:«currentPosition.y») «currentBounds»
+			'''
+			current = current.parent
+		}
+		LOG.info(message)
 	}
 	
 	def static checkRectilinearity(XConnection connection) {

--- a/de.fxdiagram.core/xtend-gen/de/fxdiagram/core/debug/Debug.java
+++ b/de.fxdiagram.core/xtend-gen/de/fxdiagram/core/debug/Debug.java
@@ -127,7 +127,7 @@ public class Debug {
         Point2D _localToParent_1 = current.localToParent(currentPosition);
         currentPosition = _localToParent_1;
         StringConcatenation _builder_1 = new StringConcatenation();
-        _builder_1.append(null, "");
+        _builder_1.append("", "");
         _builder_1.append("\tin ");
         Parent _parent = current.getParent();
         Class<? extends Parent> _class_1 = _parent.getClass();


### PR DESCRIPTION
Also removed obsolete whitespace column.

The error itself will be fixed in Xtend, this should be just cosmetics then.