### PR TITLE
Removed obsolete variable declarations

### DIFF
--- a/de.fxdiagram.docs/FXDiagram.setup
+++ b/de.fxdiagram.docs/FXDiagram.setup
@@ -46,18 +46,6 @@
       name="kieler.pragmatics"
       value="http://rtsys.informatik.uni-kiel.de/~kieler/updatesite/master"/>
   <setupTask
-      xsi:type="setup:VariableTask"
-      name="fxdiagram.git.clone.location"
-      value="${installation.location/git/}${fxdiagram.git.clone.remoteURI|gitRepository}"/>
-  <setupTask
-      xsi:type="setup:VariableTask"
-      name="fxdiagram.swtfx.git.clone.location"
-      value="${installation.location/git/}${fxdiagram.swtfx.git.clone.remoteURI|gitRepository}"/>
-  <setupTask
-      xsi:type="setup:VariableTask"
-      name="kieler.git.clone.location"
-      value="${installation.location/git/}${kieler.git.clone.remoteURI|gitRepository}"/>
-  <setupTask
       xsi:type="setup:ResourceCreationTask"
       excludedTriggers="STARTUP MANUAL"
       content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xD;&#xA;&lt;section name=&quot;Workbench&quot;>&#xD;&#xA;&#x9;&lt;section name=&quot;org.eclipse.jdt.internal.ui.packageview.PackageExplorerPart&quot;>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;true&quot; key=&quot;group_libraries&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;false&quot; key=&quot;linkWithEditor&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;2&quot; key=&quot;layout&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;2&quot; key=&quot;rootMode&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;&amp;lt;?xml version=&amp;quot;1.0&amp;quot; encoding=&amp;quot;UTF-8&amp;quot;?&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;packageExplorer configured=&amp;quot;true&amp;quot; group_libraries=&amp;quot;1&amp;quot; layout=&amp;quot;2&amp;quot; linkWithEditor=&amp;quot;0&amp;quot; rootMode=&amp;quot;2&amp;quot; sortWorkingSets=&amp;quot;false&amp;quot; workingSetName=&amp;quot;&amp;quot;&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;workingSet editPageId=&amp;quot;org.eclipse.jdt.internal.ui.OthersWorkingSet&amp;quot; factoryID=&amp;quot;org.eclipse.ui.internal.WorkingSetFactory&amp;quot; id=&amp;quot;1382792884467_1&amp;quot; label=&amp;quot;Other Projects&amp;quot; name=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;activeWorkingSet workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;allWorkingSets workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/packageExplorer&amp;gt;&quot; key=&quot;memento&quot;/>&#xD;&#xA;&#x9;&lt;/section>&#xD;&#xA;&lt;/section>&#xD;&#xA;"


### PR DESCRIPTION
Removed
- fxdiagram.git.clone.location
- fxdiagram.swtfx.git.clone.location
- kieler.git.clone.location
These variables are defined by the Git Clone Task already. Further it
could be just wrong to use the defined values, since they depend on the
Git Clone Rule specified in the installer.
