### PR TITLE
Add project descriptor with resource filter

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>FXDiagram</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1483710149108</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-de.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>


### PR DESCRIPTION
The project descriptor is automatically produced when materializing the
workspace with Oomph. The root project contains all subprojects and
resources are existing twice.
The resource filter will exclude all subprojects in the root project.

This is how the root project looks like after workspace setup:
![screenshot 32](https://cloud.githubusercontent.com/assets/265597/21719639/1d0fdc2a-d41f-11e6-99b1-333864ff9307.png)
The Open Resource dialog will list resources multiple times:
![screenshot 33](https://cloud.githubusercontent.com/assets/265597/21719643/209fcb66-d41f-11e6-84fa-fb34f7e317a4.png)

With the patch the subprojects are filtered:
![screenshot 34](https://cloud.githubusercontent.com/assets/265597/21719646/23a4f782-d41f-11e6-828f-ebe23accc226.png)
The Open Resource dialog will be more helpful now:
![screenshot 35](https://cloud.githubusercontent.com/assets/265597/21719647/263ffcb2-d41f-11e6-9576-dcb716120cca.png)
